### PR TITLE
fix: call EndArea if there are no endpoints found

### DIFF
--- a/NetworkDiscoveryHud.cs
+++ b/NetworkDiscoveryHud.cs
@@ -69,7 +69,11 @@ namespace FishNet.Discovery
 
 			GUILayout.EndHorizontal();
 
-			if (_endPoints.Count < 1) return;
+			if (_endPoints.Count < 1)
+			{
+				GUILayout.EndArea();
+				return;
+			}
 
 			GUILayout.Box("Servers");
 


### PR DESCRIPTION
If there were no endpoints found, OnGui returned without calling EndArea, resulting in errors due to mismatched Begin/End calls.